### PR TITLE
refactor: enhance SkillCard component with subtitle support and impro…

### DIFF
--- a/src/components/section/Skills/Skills.tsx
+++ b/src/components/section/Skills/Skills.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { skills } from "@/data/skills";
+import { coreSkills, toolingSkills } from "@/data/skills";
 import { SectionTitle } from "@/components/ui/SectionTitle/SectionTitle";
 import { Section } from "@/components/ui/Section/Section";
 import { SkillCard } from "@/components/ui/SkillCard/SkillCard";
@@ -16,14 +16,20 @@ const Skills: React.FC = () => {
       <div className="container mx-auto px-4">
         <div className="max-w-6xl mx-auto">
           <SectionTitle title={"Skills"}/>
-          
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-6">
-            {skills.map(({name, icon}, index) => (
-              <RevealOnScroll key={name} delay={index * 0.05} yOffset={16}>
-                <SkillCard
-                  name={name}
-                  icon={icon}
-                />
+
+          <div className="mb-12 grid grid-cols-2 gap-5 lg:grid-cols-4">
+            {coreSkills.map(({name, subtitle, icon}, index) => (
+              <RevealOnScroll key={name} delay={index * 0.04} yOffset={14}>
+                <SkillCard name={name} subtitle={subtitle} icon={icon} />
+              </RevealOnScroll>
+            ))}
+          </div>
+
+          <h3 className="mb-5 text-primary font-medium text-center">Tooling</h3>
+          <div className="mx-auto grid max-w-4xl grid-cols-2 gap-5 lg:grid-cols-4">
+            {toolingSkills.map(({name, subtitle, icon}, index) => (
+              <RevealOnScroll key={name} delay={index * 0.04} yOffset={14}>
+                <SkillCard name={name} subtitle={subtitle} icon={icon} />
               </RevealOnScroll>
             ))}
           </div>

--- a/src/components/ui/SkillCard/SkillCard.tsx
+++ b/src/components/ui/SkillCard/SkillCard.tsx
@@ -5,43 +5,49 @@ import { IconType } from 'react-icons'
 interface SkillCardProps {
   icon: IconType
   name: string
+  subtitle?: string
   className?: string
 }
 
 export const SkillCard: FC<SkillCardProps> = ({
                                                 icon: Icon,
                                                 name,
+                                                subtitle,
                                                 className
                                               }) => {
   return (
     <div
       data-testid="skill-card"
       className={cn(
-        "group flex flex-col items-center p-6",
-        "bg-zinc-50 dark:bg-zinc-700/30",
+        "group flex min-h-[140px] flex-col items-center justify-between p-5",
+        "bg-slate-50 dark:bg-zinc-700/30 border border-slate-200 dark:border-zinc-700/60",
         "rounded-lg",
         "transition-all duration-300 shadow-md",
-        "hover:-translate-y-1 hover:scale-105",
-        "hover:bg-zinc-100 dark:hover:bg-zinc-700/50",
+        "hover:-translate-y-1",
+        "hover:bg-white dark:hover:bg-zinc-700/50",
         "hover:shadow-lg",
         className
       )}>
-      <div className="relative mb-4">
-        <Icon
-          data-testid="skill-card-icon"
-          className={cn(
-            "w-8 h-8 text-secondary dark:text-secondary",
-            "transition-transform duration-500",
-            "group-hover:scale-125 group-hover:rotate-45"
-          )}
-        />
+      <Icon
+        data-testid="skill-card-icon"
+        className={cn(
+          "w-7 h-7 text-secondary dark:text-secondary",
+          "transition-transform duration-500",
+          "group-hover:scale-110"
+        )}
+      />
+
+      <div className="w-full text-center">
+        <p
+          data-testid="skill-card-name"
+          className="min-h-[2.5rem] text-sm font-medium leading-tight text-primary flex items-center justify-center"
+        >
+          {name}
+        </p>
+        <p className="min-h-[2.25rem] text-xs leading-snug text-secondary">
+          {subtitle ?? "\u00A0"}
+        </p>
       </div>
-      
-      <span
-        data-testid="skill-card-name"
-        className="text-primary font-medium text-sm text-center">
-        {name}
-      </span>
     </div>
   )
 }

--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -1,25 +1,38 @@
+import { IconType } from "react-icons";
+import { FaMicrosoft, FaUniversalAccess } from "react-icons/fa";
+import { LuWorkflow } from "react-icons/lu";
 import {
-  SiAntdesign,
+  SiAmazonwebservices,
   SiGit,
-  SiJest,
-  SiMaterialdesign,
   SiNextdotjs,
   SiReact,
   SiReactquery,
-  SiRedux,
-  SiTailwindcss,
+  SiStorybook,
+  SiSwagger,
+  SiTestinglibrary,
   SiTypescript
 } from "react-icons/si";
 
-export const skills = [
-  {name: 'React', icon: SiReact},
-  {name: 'TypeScript', icon: SiTypescript},
-  {name: 'Next.js', icon: SiNextdotjs},
-  {name: 'Tailwind', icon: SiTailwindcss},
-  {name: 'Git', icon: SiGit},
-  {name: 'Material UI', icon: SiMaterialdesign},
-  {name: 'Ant Design', icon: SiAntdesign},
-  {name: 'Jest', icon: SiJest},
-  {name: 'Redux', icon: SiRedux},
-  {name: 'React Query', icon: SiReactquery},
-]
+export type SkillItem = {
+  name: string;
+  subtitle?: string;
+  icon: IconType;
+};
+
+export const coreSkills: SkillItem[] = [
+  { name: "React", subtitle: "UI library", icon: SiReact },
+  { name: "TypeScript", subtitle: "Static typing", icon: SiTypescript },
+  { name: "Next.js", subtitle: "React framework",icon: SiNextdotjs },
+  { name: "Micro-frontends", subtitle: "Single-SPA + Module Federation", icon: LuWorkflow },
+  { name: "State Management", subtitle: "React Query + Zustand", icon: SiReactquery },
+  { name: "Testing & Quality", subtitle: "Jest + React Testing Library", icon: SiTestinglibrary },
+  { name: "Accessibility", subtitle: "WCAG", icon: FaUniversalAccess },
+  { name: "Design Systems", subtitle: "Consistency at scale", icon: SiStorybook },
+];
+
+export const toolingSkills: SkillItem[] = [
+  { name: "AWS", subtitle: "S3 + CloudFront", icon: SiAmazonwebservices },
+  { name: "Azure DevOps", subtitle: "CI/CD workflows", icon: FaMicrosoft },
+  { name: "Swagger / OpenAPI", subtitle: "Practical API integration", icon: SiSwagger },
+  { name: "Git", subtitle: "Version control", icon: SiGit },
+];


### PR DESCRIPTION
## Context
Refactors the Skills section to improve structure and visual clarity by separating core competencies from tooling and adding subtitles to each card.

## What changed
- Introduced `SkillItem` and split skill data into:
  - `coreSkills`
  - `toolingSkills`
- Updated `SkillCard` to accept `subtitle?: string`.
- Refined `SkillCard` layout and styling

## Why
- Better semantic structure for skill data.
- Improved scannability for recruiters and technical reviewers.
- More consistent card presentation across varied content lengths.

## Impact
- UI/data changes limited to the Skills section.
- No business logic impact.