### PR TITLE
feat: redesign hero section with updated styles, content, and layout …

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,6 +19,7 @@
     --color-accent: #7657ff;
     --color-accent-strong: #5938db;
     --color-accent-soft: #ebe6ff;
+    --color-on-accent: #ffffff;
 
     /* Legacy aliases while components migrate to semantic tokens */
     --color-primary: var(--color-ink);
@@ -60,6 +61,7 @@
     --color-accent: #a68cff;
     --color-accent-strong: #b8a4ff;
     --color-accent-soft: #2e2748;
+    --color-on-accent: #19171f;
 
     --color-primary: var(--color-ink);
     --color-primary-light: #ffffff;
@@ -141,7 +143,7 @@ h3 {
     }
 
     .button-primary {
-        @apply inline-flex items-center justify-center gap-2 rounded-control bg-accent px-5 py-2.5 font-medium text-white shadow-soft transition-all duration-300 hover:-translate-y-0.5 hover:bg-accent-strong hover:shadow-lift focus-ring;
+        @apply inline-flex items-center justify-center gap-2 rounded-control bg-accent px-5 py-2.5 font-medium text-accent-contrast shadow-soft transition-all duration-300 hover:-translate-y-0.5 hover:bg-accent-strong hover:shadow-lift focus-ring;
     }
 
     .profile-image-container {
@@ -167,6 +169,59 @@ h3 {
         animation-iteration-count: 1 !important;
         scroll-behavior: auto !important;
         transition-duration: 0.01ms !important;
+    }
+}
+
+.hero-squircle {
+    border-radius: 28% 16% 24% 18% / 20% 26% 18% 24%;
+}
+
+.hero-squircle-accent {
+    border-radius: 18% 26% 16% 24% / 28% 18% 24% 16%;
+}
+
+/* Keep the full hero visible on wide laptops with limited vertical space. */
+@media (min-width: 1024px) and (max-height: 850px) {
+    .hero-viewport {
+        min-height: calc(100svh - 4rem);
+        padding-block: 2rem;
+    }
+
+    .hero-layout {
+        gap: 3rem;
+    }
+
+    .hero-heading {
+        margin-top: 1rem;
+        font-size: clamp(3.75rem, 8vh, 4.75rem);
+    }
+
+    .hero-tagline {
+        margin-top: 1.25rem;
+        font-size: clamp(1.5rem, 3.5vh, 2rem);
+    }
+
+    .hero-description {
+        margin-top: 1rem;
+        font-size: 1rem;
+        line-height: 1.55;
+    }
+
+    .hero-actions {
+        margin-top: 1.25rem;
+    }
+
+    .hero-socials {
+        margin-top: 0.75rem;
+    }
+
+    .hero-highlights {
+        margin-top: 1.5rem;
+        padding-block: 0.75rem;
+    }
+
+    .hero-portrait {
+        max-width: 17.5rem;
     }
 }
 

--- a/src/components/section/Hero/Hero.test.tsx
+++ b/src/components/section/Hero/Hero.test.tsx
@@ -23,9 +23,11 @@ describe("Hero Component", () => {
 
     expect(screen.getByTestId("hero-image")).toBeInTheDocument();
     expect(screen.getByTestId("social-links")).toBeInTheDocument();
-    expect(screen.getByTestId("hero-intro")).toHaveTextContent("Hi there, I'm");
+    expect(screen.getByTestId("hero-intro")).toHaveTextContent("Frontend Developer · England, UK");
     expect(screen.getByRole("heading", {level: 1})).toHaveTextContent("Patricia Segantine");
-    expect(screen.getByText(HERO_CONTENT.title.trim())).toBeInTheDocument();
+    expect(screen.getByText(/Interfaces that stay clear/)).toBeInTheDocument();
     expect(screen.getByText(HERO_CONTENT.subtitle)).toBeInTheDocument();
+    expect(screen.getByRole("link", {name: /Explore selected work/i})).toHaveAttribute("href", "#projects");
+    expect(screen.getByRole("link", {name: /More about me/i})).toHaveAttribute("href", "#about");
   });
 });

--- a/src/components/section/Hero/Hero.tsx
+++ b/src/components/section/Hero/Hero.tsx
@@ -1,15 +1,23 @@
 'use client'
 
 import React from 'react'
+import Link from 'next/link'
+import { ArrowDownRight, ArrowRight } from 'lucide-react'
 import SocialLinks from "@/components/ui/SocialLinks/SocialLinks";
 import HeroImage from "@/components/ui/HeroImage/HeroImage";
 import { Section } from "@/components/ui/Section/Section";
 import type { HeroContent } from "@/types/hero";
 
 export const HERO_CONTENT: HeroContent = {
-  title: "Frontend Developer ",
-  subtitle: "Focused on clean interfaces, scalable architecture, and understanding how the full picture fits together.",
+  title: "Interfaces that stay clear as products grow.",
+  subtitle: "I turn complex product requirements into accessible, maintainable frontend experiences, with a sharp eye for the details and the system behind them.",
 };
+
+const HERO_HIGHLIGHTS = [
+  { value: '6 years', label: 'building products' },
+  { value: 'B2B + B2C', label: 'SaaS experience' },
+  { value: 'React ecosystem', label: 'core expertise' },
+];
 
 const Hero: React.FC = () => {
 
@@ -18,34 +26,65 @@ const Hero: React.FC = () => {
       id="home"
       variant="primary"
       aria-label="Home"
-      className="flex items-center justify-center min-h-[calc(100svh-4rem)] md:min-h-screen py-0"
+      className="hero-viewport relative isolate flex min-h-[calc(100svh-4rem)] items-center overflow-hidden py-16 md:min-h-[calc(100svh-5rem)] md:py-24"
     >
-      <div className="container mx-auto px-4">
-        <div className="mx-auto flex max-w-6xl flex-col items-center gap-12 md:flex-row md:items-start">
-          <HeroImage/>
+      <div className="pointer-events-none absolute inset-0 -z-10" aria-hidden="true">
+        <div className="absolute -right-32 top-10 h-96 w-96 rounded-full bg-accent opacity-[0.08] blur-3xl" />
+        <div className="absolute inset-y-0 left-[4.5%] hidden w-px bg-line xl:block" />
+        <span className="absolute left-[4.5%] top-[70%] hidden -translate-x-1/2 -translate-y-1/2 font-display text-[10px] font-semibold uppercase tracking-[0.28em] text-ink-subtle [writing-mode:vertical-rl] xl:block">
+          Portfolio · 2026
+        </span>
+      </div>
 
-          <div className="flex flex-1 flex-col items-center gap-6 text-center md:items-start md:text-left">
-            <div className="flex items-center gap-2 text-secondary dark:text-secondary" data-testid="hero-intro">
-              <span className="hidden md:block w-6 h-[2px] bg-zinc-300 dark:bg-zinc-600"/>
-              <span>Hi there, I&apos;m</span>
+      <div className="container mx-auto px-5 sm:px-8">
+        <div className="hero-layout mx-auto grid max-w-7xl items-center gap-14 lg:grid-cols-[minmax(0,1.15fr)_minmax(20rem,0.85fr)] lg:gap-20">
+          <div className="flex min-w-0 flex-col items-start text-left">
+            <div className="eyebrow flex items-center gap-3" data-testid="hero-intro">
+              <span className="h-2 w-2 rotate-45 bg-accent" aria-hidden="true" />
+              <span>Frontend Developer · England, UK</span>
             </div>
 
-            <h1 className="text-3xl md:text-5xl lg:text-6xl font-bold text-primary">
+            <h1 className="hero-heading mt-7 max-w-4xl font-display text-5xl font-semibold leading-[0.94] tracking-[-0.065em] text-primary sm:text-6xl md:text-7xl xl:text-[5.5rem]">
               Patricia Segantine
             </h1>
 
-            <p className="text-xl md:text-2xl lg:text-3xl text-secondary min-h-8 md:min-h-10">
-              {HERO_CONTENT.title}
+            <p className="hero-tagline mt-7 max-w-3xl font-display text-2xl font-medium leading-tight tracking-[-0.035em] text-primary sm:text-3xl md:text-4xl">
+              Interfaces that stay clear <span className="text-accent-strong">as products grow.</span>
             </p>
 
-            <p className="text-lg text-secondary leading-relaxed max-w-2xl min-h-32 md:min-h-24">
+            <p className="hero-description mt-6 max-w-2xl text-base leading-relaxed text-secondary sm:text-lg">
               {HERO_CONTENT.subtitle}
             </p>
 
-            <div className="min-h-11 flex items-center">
+            <div className="hero-actions mt-8 flex w-full flex-col gap-3 sm:w-auto sm:flex-row">
+              <Link href="#projects" className="button-primary group">
+                Explore selected work
+                <ArrowDownRight className="h-4 w-4 transition-transform duration-300 group-hover:translate-x-0.5 group-hover:translate-y-0.5" />
+              </Link>
+              <Link
+                href="#about"
+                className="group inline-flex items-center justify-center gap-2 rounded-control border border-line bg-surface px-5 py-2.5 font-medium text-primary transition-all duration-300 hover:-translate-y-0.5 hover:border-accent hover:text-accent-strong focus-ring"
+              >
+                More about me
+                <ArrowRight className="h-4 w-4 transition-transform duration-300 group-hover:translate-x-1" />
+              </Link>
+            </div>
+
+            <div className="hero-socials mt-5 flex min-h-11 items-center">
               <SocialLinks showLabel={true}/>
             </div>
+
+            <dl className="hero-highlights mt-10 grid w-full grid-cols-3 border-y border-line py-5 sm:max-w-2xl">
+              {HERO_HIGHLIGHTS.map(({value, label}) => (
+                <div key={value} className="border-l border-line px-3 first:border-l-0 first:pl-0 sm:px-5 sm:first:pl-0">
+                  <dt className="font-display text-sm font-semibold text-primary sm:text-base">{value}</dt>
+                  <dd className="mt-1 text-[0.68rem] leading-tight text-ink-subtle sm:text-xs">{label}</dd>
+                </div>
+              ))}
+            </dl>
           </div>
+
+          <HeroImage/>
         </div>
       </div>
     </Section>

--- a/src/components/ui/HeroImage/HeroImage.tsx
+++ b/src/components/ui/HeroImage/HeroImage.tsx
@@ -3,24 +3,21 @@ import Image from 'next/image'
 
 const HeroImage: React.FC = () => {
   return (
-    <div className="relative w-56 h-56 md:w-72 md:h-72" data-testid="hero-image">
-      <div
-        className="absolute inset-0 bg-zinc-100/50 dark:bg-zinc-700/30 rounded-full -rotate-6 transform transition-all duration-custom group-hover:rotate-6"/>
-      
-      <div
-        className="relative w-full h-full rounded-full p-[2px] bg-gradient-to-tr from-zinc-200/60 via-zinc-300/40 to-transparent dark:from-zinc-600/40 dark:via-zinc-700/20 dark:to-transparent">
-        <div className="w-full h-full rounded-full bg-white dark:bg-zinc-800 p-[2px]">
+    <div className="hero-portrait group relative mx-auto w-full max-w-[18rem] sm:max-w-[20rem] lg:max-w-[21rem]" data-testid="hero-image">
+      <div className="hero-squircle-accent absolute -bottom-3 -right-3 h-2/3 w-2/3 bg-accent-soft transition-transform duration-700 ease-out group-hover:translate-x-1 group-hover:translate-y-1" aria-hidden="true" />
+
+      <div className="hero-squircle relative aspect-[4/5] overflow-hidden bg-canvas-muted shadow-soft">
+        <div className="hero-squircle relative h-full w-full overflow-hidden">
           <Image
             src="https://github.com/patriciasegantine.png"
             alt="Profile picture of Patricia Segantine"
             fill
-            className="rounded-full ring-1 ring-zinc-100 dark:ring-zinc-700 "
+            priority
+            sizes="(min-width: 1024px) 21rem, (min-width: 640px) 20rem, 90vw"
+            className="object-cover object-[center_35%] transition-transform duration-700 ease-out group-hover:scale-[1.025]"
           />
         </div>
       </div>
-      
-      <div className="absolute -bottom-2 -right-2 w-3 h-3 rounded-full bg-zinc-200/80 dark:bg-zinc-600/50"/>
-      <div className="absolute -top-2 -left-2 w-4 h-4 rounded-full bg-zinc-100/80 dark:bg-zinc-700/50"/>
     </div>
   )
 }

--- a/src/components/ui/SocialLinks/SocialLinks.tsx
+++ b/src/components/ui/SocialLinks/SocialLinks.tsx
@@ -16,17 +16,17 @@ const SocialLinks: React.FC<SocialLinksProps> = ({showLabel = false}) => {
   };
   
   return (
-    <div className="flex gap-4" data-testid="social-links">
+    <div className="flex flex-wrap gap-3" data-testid="social-links">
       {socialLinks.map((social) => (
         <a
           key={social.name}
           href={social.href}
           target="_blank"
           rel="noopener noreferrer"
-          className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm transition-colors text-secondary bg-zinc-100 border border-zinc-200 dark:border-zinc-700/50 dark:bg-zinc-700/50 hover:bg-zinc-200 dark:hover:bg-zinc-700/80 focus-ring"
+          className="group flex items-center gap-2 rounded-control border border-line bg-transparent px-3 py-2 text-sm text-secondary transition-all duration-300 hover:border-accent hover:bg-accent-soft hover:text-accent-strong focus-ring"
           aria-label={`Visit ${social.name} profile`}
         >
-          {React.createElement(icons[social.icon] || icons.default, {className: "w-5 h-5"})}
+          {React.createElement(icons[social.icon] || icons.default, {className: "h-4 w-4 transition-transform duration-300 group-hover:-rotate-6"})}
           {showLabel && <span>{social.name}</span>}
         </a>
       ))}

--- a/src/components/ui/SubmitButton/SubmitButton.tsx
+++ b/src/components/ui/SubmitButton/SubmitButton.tsx
@@ -10,7 +10,7 @@ const SubmitButton = ({isLoading}: SubmitButtonProps) => {
       data-testid="submit-button"
       type="submit"
       className={`relative w-full inline-flex items-center justify-center gap-2 px-6 py-3
-              rounded-control text-white font-medium transition-all duration-300
+              rounded-control text-accent-contrast font-medium transition-all duration-300
               focus-ring
               ${isLoading
                 ? "cursor-not-allowed bg-accent opacity-70"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -30,6 +30,7 @@ const config: Config = {
           DEFAULT: 'var(--color-accent)',
           strong: 'var(--color-accent-strong)',
           soft: 'var(--color-accent-soft)',
+          contrast: 'var(--color-on-accent)',
         },
         line: 'var(--color-line)',
         primary: {


### PR DESCRIPTION
## Summary

- Redesigns the Hero section with a two-column grid layout (text left, image right), replacing the centered single-column approach
- Adds CTA buttons ("Explore selected work" → `#projects`, "More about me" → `#about`) and a highlights bar with key stats (6 yrs, B2B+B2C, React ecosystem)
- Replaces the circular profile photo with an organic squircle shape with hover scale + accent accent decorative layer
- Introduces `--color-on-accent` semantic token and `accent.contrast` Tailwind alias so button text adapts to light/dark mode instead of hardcoding `text-white`
- Adds a `@media (min-width:1024px) and (max-height:850px)` breakpoint to keep the full hero visible on wide laptops with limited vertical space
- Updates `SocialLinks` and `SubmitButton` to use the new design-system tokens
- Updates Hero tests to match the new content and CTA links