### PR TITLE
feat: redesign About section with new content structure and principle…

### DIFF
--- a/src/components/section/About/About.tsx
+++ b/src/components/section/About/About.tsx
@@ -1,10 +1,8 @@
 'use client'
 
 import React from 'react'
-import { SectionTitle } from "@/components/ui/SectionTitle/SectionTitle";
 import { Section } from "@/components/ui/Section/Section";
-import { TextContent } from "@/components/ui/TextContent/TextContent";
-import { aboutMe } from "@/data/aboutMe";
+import { ABOUT_ME, ABOUT_PRINCIPLES } from "@/data/aboutMe";
 
 const About: React.FC = () => {
   return (
@@ -13,16 +11,46 @@ const About: React.FC = () => {
       variant="secondary"
       aria-label="About"
     >
-      <div className="container mx-auto px-4">
-        <div className="max-w-6xl mx-auto prose dark:prose-dark">
-          <SectionTitle title={"About"} />
+      <div className="container mx-auto px-5 sm:px-8">
+        <div className="mx-auto max-w-7xl">
+          <div className="grid gap-10 lg:grid-cols-[0.8fr_1.2fr] lg:gap-16 xl:gap-24">
+            <div>
+              <p className="eyebrow flex items-center gap-3">
+                <span className="h-2 w-2 rotate-45 bg-accent" aria-hidden="true" />
+                02 · About
+              </p>
 
-          <div className="text-lg text-secondary dark:text-secondary leading-relaxed space-y-4">
-            {aboutMe.paragraphs.map((paragraph, index) => (
-              <TextContent key={index}>
-                {paragraph}
-              </TextContent>
-            ))}
+              <h2 className="mt-5 font-display text-5xl font-semibold tracking-[-0.055em] text-primary md:text-6xl">
+                About
+              </h2>
+
+              <p className="mt-8 max-w-md font-display text-2xl font-medium leading-tight tracking-[-0.035em] text-primary md:text-3xl">
+                The frontend is where product decisions <span className="text-accent-strong">become real.</span>
+              </p>
+            </div>
+
+            <div className="flex flex-col justify-end lg:pb-1">
+              <p className="text-xl leading-relaxed text-primary md:text-2xl">
+                {ABOUT_ME[0].text}
+              </p>
+              <p className="mt-5 max-w-3xl text-base leading-relaxed text-secondary md:text-lg">
+                {ABOUT_ME[1].text}
+              </p>
+            </div>
+          </div>
+
+          <div className="mt-14 border-t border-line pt-8 lg:mt-16">
+            <p className="mb-4 text-xs font-semibold uppercase tracking-[0.16em] text-ink-subtle">
+              How I work
+            </p>
+            <div className="grid gap-8 md:grid-cols-3 md:gap-0">
+              {ABOUT_PRINCIPLES.map(({number, title, description}) => (
+                <div key={number} className="border-t border-line pt-5 md:border-l md:border-t-0 md:px-8 md:pt-0 md:first:border-l-0 md:first:pl-0 md:last:pr-0">
+                  <h3 className="mt-3 font-display text-xl font-semibold text-primary">{title}</h3>
+                  <p className="mt-2 max-w-sm text-sm leading-relaxed text-secondary">{description}</p>
+                </div>
+              ))}
+            </div>
           </div>
         </div>
       </div>

--- a/src/data/aboutMe.ts
+++ b/src/data/aboutMe.ts
@@ -1,6 +1,24 @@
-export const aboutMe = {
-  paragraphs: [
-    "I'm a Frontend Developer with 6 years of experience building user-facing applications for B2B and B2C SaaS products, working mainly with React, TypeScript, and Next.js in micro-frontend environments where performance, accessibility, and maintainability matter at scale.",
-    "I work closely with Product, Design, and backend teams, contributing to technical discussions, flagging trade-offs early, and taking ownership of what I ship. I care about frontend that is reliable, easy to evolve, and built with the people who will use and maintain it in mind."
-  ]
-}
+const ABOUT_ME = [
+  { text: "I'm a Frontend Developer with 6 years of experience building B2B and B2C SaaS products with React, TypeScript, and Next.js. I focus on accessible, maintainable interfaces that can evolve with the product." },
+  { text: "Most of my work happens in micro-frontend environments, where several teams ship into the same product. That shapes how I think about structure, consistency, and the decisions that keep a frontend healthy as it grows." },
+]
+
+const ABOUT_PRINCIPLES = [
+  {
+    number: '01',
+    title: 'Think in systems',
+    description: 'Build foundations that stay understandable as the product grows.',
+  },
+  {
+    number: '02',
+    title: 'Work in context',
+    description: 'Connect Product, Design, and backend decisions before they become UI problems.',
+  },
+  {
+    number: '03',
+    title: 'Own the outcome',
+    description: 'Ship with accessibility, maintainability, and the next developer in mind.',
+  },
+];
+
+export { ABOUT_ME, ABOUT_PRINCIPLES };


### PR DESCRIPTION
## Summary

- Replaced flat text layout with a two-column grid (bio on the left, expanded copy on the right) using a responsive `lg:grid-cols-[0.8fr_1.2fr]` split
- Added an eyebrow label (`02 · About`) with accent diamond marker, and a tagline anchoring the section intent
- Introduced a "How I work" principles strip below the bio — three columns (Think in systems / Work in context / Own the outcome) separated by border lines
- Refactored `aboutMe.ts` into two named exports (`ABOUT_ME`, `ABOUT_PRINCIPLES`) and rewrote the copy for clarity and concision
- Removed `SectionTitle` and `TextContent` wrappers in favour of inline typography classes consistent with the design system
